### PR TITLE
remove virtzone.net, no longer exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,7 +396,6 @@ Table of Contents
   * [exoscale.ch](https://www.exoscale.ch/) — Free resources for Open Source
   * [developer.rackspace.com](https://developer.rackspace.com/) — Rackspace Cloud gives USD 50/month for 12 months
   * [cloud.google.com/compute](https://cloud.google.com/compute/) — Google Compute Engine gives USD 300 over 60 days
-  * [virtzone.net](http://www.virtzone.net/) — Free VPS. You must meet certain minor qualifications
   * [backblaze.com](https://backblaze.com/b2/) — Backblaze B2 cloud storage. Free 10 GB (Amazon S3-like) object storage for unlimited time
   * [trystack.org](http://trystack.org/) — Free Openstack hosting. The environment is resets every 24 hours, suitable for testing only
   * [dply.co](https://dply.co/) — Create a cloud server FREE for 2 hours. Backend host is Digitalocean.


### PR DESCRIPTION
  * [virtzone.net](http://www.virtzone.net/) — Free VPS. You must meet certain minor qualifications

This domain does not host a website. No reference to the mentioned services could be found.