### PR TITLE
Remove stackahoy.io as it now takes you to a Polish loan website.

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,6 @@ Table of Contents
   * [codefresh.io](https://codefresh.io) — Free-for-Life plan: 1 build, 1 environment, shared servers, unlimited public repos
   * [codeship.com](https://codeship.com/) — 100 private builds/month, 5 private projects, unlimited for Open Source
   * [circleci.com](https://circleci.com/) — Free for one concurrent build
-  * [stackahoy.io](https://stackahoy.io) — 100% free. Unlimited deployments, branches and builds
   * [travis-ci.org](https://travis-ci.org/) — Free for public GitHub repositories
   * [wercker.com](http://wercker.com/) — Free for public and private repositories
   * [drone.io](https://drone.io/) — CI platform that includes browser testing, free for Open Source


### PR DESCRIPTION
I was reading through the list and noticed stackahoy.io - sounded too good to be true and unfortunately is - at the moment at least.
<img width="1357" alt="image" src="https://github.com/jixserver/free-for-dev/assets/144782839/98b01407-1cc1-460d-8e5f-016b0b520061">
